### PR TITLE
Media Pluralization

### DIFF
--- a/lib/wistia/media.rb
+++ b/lib/wistia/media.rb
@@ -1,5 +1,7 @@
 module Wistia
   class Media < Wistia::Base
+    
+    self.collection_name = 'medias'
 
     def still(width = 640, options = {})
       options = {:format => 'jpg', :style => 'image_resize'}.merge(options)


### PR DESCRIPTION
fixed an issue where 'media' was being pluralized as 'media' instead of 'medias'
