### PR TITLE
Fix for JRuby 1.7+

### DIFF
--- a/lib/config.rb
+++ b/lib/config.rb
@@ -3,13 +3,18 @@
 # https://github.com/markbates/configatron/pull/33
 # but the patch has not been applied for months
 
-if RUBY_PLATFORM == 'java' && !defined? Psych::Yecht
+def running_jruby_1_7_or_later
+  RUBY_PLATFORM == 'java' && !JRUBY_VERSION.match(/[0-1]\.[0-6]/)
+end
+
+if running_jruby_1_7_or_later && !defined? Psych::Yecht
   module Psych
     module Yecht
       MergeKey = Psych::Syck
     end
   end
 end
+
 require 'configatron'
 
 configatron.wistia.api.key = ''


### PR DESCRIPTION
JRuby 1.7 uses the 'syck' YAML engine instead of 'yecht'.  This breaks configatron because it depends on Yecht.  That issue was reported months ago but the patch has not been applied so this patch represents pragmatic solution to the issue.

https://github.com/markbates/configatron/pull/33

We have applied the same patch in our (rails) wistia initializer and it works fine.  I couldn't get your specs to run though (even before I applied this change) so apologies if I have inadvertantly broken something.
